### PR TITLE
Update to support IDEA 241.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.gradle/
 /.idea/
+/build/
 /fabric/.gradle/
 /fabric/build/
 /fabric/run/

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.4-SNAPSHOT'
+    id 'fabric-loom' version '1.7-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,15 +1,15 @@
 # Fabric Properties
 	# check these on https://fabricmc.net/develop/
 	minecraft_version = 1.20.4
-	yarn_mappings = 1.20.4+build.1
-	loader_version = 0.15.1
+	yarn_mappings = 1.20.4+build.3
+	loader_version = 0.15.11
 
 # Mod Properties
-	mod_version = 3.0.4
+	mod_version = 3.0.5
 	maven_group = me.jaffe2718
 	archives_base_name = cmdkit
 	compatible_minecraft_versions = 1.20.4
 
 # Dependencies
 	# check this on https://fabricmc.net/develop/
-	fabric_version = 0.91.2+1.20.4
+	fabric_version = 0.97.1+1.20.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     id "java"
     // id "org.jetbrains.kotlin:kotlin-gradle-plugin" version '1.9.21'
-    id "org.jetbrains.intellij" version "1.16.1"
+    id "org.jetbrains.intellij" version "1.17.4"
 }
 
 group = 'me.jaffe2718'
@@ -43,7 +43,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild = '233.0'
-        untilBuild = '233.*'
+        untilBuild = '241.*'
     }
 
     signPlugin {

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <id>me.jaffe2718.devkit</id>
 
     <name>Minecraft Command DevKit</name>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <vendor email="qqyttwqeei@163.com" url="https://github.com/Jaffe2718">Jaffe2718</vendor>
     <description>
         <![CDATA[
@@ -65,7 +65,7 @@
                 <body>
                     <h2>Changelog</h2>
                     <ol>
-                        <li>IDEA 233.x support</li>
+                        <li>IDEA 241.x support</li>
                     </ol>
                 </body>
             </html>


### PR DESCRIPTION
- Adds support for IDEA 241
- Bumps Fabric mod dependencies to latest versions for 1.20.4
- Bumps Gradle to 8.8

Fixes #17 